### PR TITLE
Type definition has implicit any

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,5 +7,5 @@ export default class TinyQueue<Item> {
   constructor (items? : Item[], compare? : Comparator<Item>);
   peek () : Item;
   pop () : Item;
-  push (Item) : void;
+  push (item: Item) : void;
 }


### PR DESCRIPTION
Hi,

The typescript definition (unintentionally) has an implicit any, which means it won't compile for most projects.

The variable name looks like it meant to be a type; giving it a name will make the problem go away.

Thanks