### PR TITLE
Making comparator definition less strict

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 export declare type Item = any;
-export declare type Comparator<Item> = (a: Item, b: Item) => -1 | 0 | 1;
+export declare type Comparator<Item> = (a: Item, b: Item) => number;
 
 export default class TinyQueue<Item> {
   public data : Item[];


### PR DESCRIPTION
The type definition requires that a compare function can only ever return -1, 0 or 1.

The tinyqueue code only cares whether about whether the value it returns is >= 0, so this extra strictness seems superfluous, and means we can't use a function that is defined as returning a number without type assertions.

Relaxing this would make a custom compare functions slightly easier to use.