### PR TITLE
Fix bench

### DIFF
--- a/bench.js
+++ b/bench.js
@@ -6,7 +6,7 @@ const N = 1000000;
 const data = [];
 for (let i = 0; i < N; i++) data[i] = {value: Math.random()};
 
-const q = new TinyQueue(null, compare);
+const q = new TinyQueue([], compare);
 
 function compare(a, b) {
     return a.value - b.value;


### PR DESCRIPTION
In `bench.js`, `null` is passed to the constructor as `data`, which will cause an error when trying to run the bench.

```txt
TypeError: Cannot read property 'length' of null
    at new TinyQueue (tinyqueue/index.js:5:33)
    at Object.<anonymous> (tinyqueue/bench.js:9:11)
    at Generator.next (<anonymous>)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

Should pass `[]` instead.